### PR TITLE
[ADD] ESP32 SPI SD Card library.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 # added by mrubyc-utils
 build/
 
+# emacs backup file
+*.c~
+*.h~
+

--- a/example/en/master.rb.sdcard
+++ b/example/en/master.rb.sdcard
@@ -1,0 +1,75 @@
+if SDSPI.spi_bus_initialize(23, 19, 18) # Passing MOSI, MISO, CLOCK
+  if SDSPI.esp_vfs_fat_sdspi_mount(5, "/sdcard") # Passing ChipSelect, MountPoint
+    # TEST Deleting files, delete the file of given file name.
+    ESP32_STDIO.remove("/sdcard/bar.txt")
+    ESP32_STDIO.remove("/sdcard/piyo.txt")
+
+    # TEST Opening open.txt.
+    puts "open foo.txt"
+    # Open with fopen. r is read mode, pass file name and mode.
+    fid = ESP32_STDIO.fopen("/sdcard/foo.txt", "r")
+    # Reading contents of file with fgets, second argument is maximum length of reading.
+    cont = ESP32_STDIO.fgets(fid, 64)
+    puts cont
+    # Closing file with fclose.
+    ESP32_STDIO.fclose(fid)
+
+    # TEST Creating bar.txt and write in.
+    puts "\nHey, create bar.txt and write down"
+    # w is write mode
+    fid = ESP32_STDIO.fopen("/sdcard/bar.txt", "w")
+    # Writing in with fputs.
+    ESP32_STDIO.fputs(fid, "Hello mruby/c!")
+    # fputc writes only first character.
+    ESP32_STDIO.fputc(fid, "?")
+    ESP32_STDIO.fclose(fid)
+
+    # TEST Renaming files.
+    puts "\nYo! rename bar.txt to piyo.txt and read it!"
+    # rename bar.txt to piyo.txt
+    ESP32_STDIO.rename("/sdcard/bar.txt", "/sdcard/piyo.txt")
+
+    # Check piyo.txt is available.
+    fid = ESP32_STDIO.fopen("/sdcard/piyo.txt", "r")
+    # Should print "Hello mruby/c!?"
+    cont =ESP32_STDIO.fgets(fid,64)
+
+    # TEST Seeking
+    puts "\n Let's fseek!"
+    # Moving cursor to 5th character(It's 4 counting from 0). Second argument, 0 is from-head, 1 is from-cursor, 2 is from-last.
+    ESP32_STDIO.fseek(fid, 4, 0)
+    # Where is current position?(should 4)
+    pos = ESP32_STDIO.fgetpos(fid)
+    puts "position is ", pos
+    puts "\n fgetc, Yah!"
+    # Should print 'o', it's 5th character of 'Hello'.
+    puts ESP32_STDIO.fgetc(fid)
+    puts cont
+    ESP32_STDIO.fclose(fid)
+
+    # Let's enumearate child directories and files.
+    puts "\nGet ls /sdcard!"
+    ls = ESP32_DIRENT.children("/sdcard")
+    p ls
+
+    # Let's check created date of file.
+    puts "\nWhen created? Check it now!"
+    t = ESP32_DIRENT.fileTime("/sdcard/piyo.txt")
+    puts "Year:", t.getYear()
+    puts "Month:", t.getMonth()
+    
+    # Clear up.
+    SDSPI.esp_vfs_fat_sdcard_unmount()
+
+  else
+    puts "vfat mount error"
+  end
+  SDSPI.spi_bus_free()
+else
+  puts "bus initialize error"
+end
+
+while true
+  puts "hello world from ESP32"
+  sleep 100
+end

--- a/example/ja/master.rb.sdcard
+++ b/example/ja/master.rb.sdcard
@@ -1,0 +1,75 @@
+if SDSPI.spi_bus_initialize(23, 19, 18) # MOSI, MISO, CLOCKをわたす
+  if SDSPI.esp_vfs_fat_sdspi_mount(5, "/sdcard") # ChipSelect, MountPointをわたす
+    # ファイルの削除，削除するファイル名をわたす
+    ESP32_STDIO.remove("/sdcard/bar.txt")
+    ESP32_STDIO.remove("/sdcard/piyo.txt")
+
+    # open.txtを開くテスト
+    puts "open foo.txt"
+    # fopenで開く, rは読み込みモード，ファイル名とモードをわたす
+    fid = ESP32_STDIO.fopen("/sdcard/foo.txt", "r")
+    # fgetsでファイルの内容を読む，二つの引数は読みこむ最大文字数
+    cont = ESP32_STDIO.fgets(fid, 64)
+    puts cont
+    # fcloseを使ってファイルを閉じる
+    ESP32_STDIO.fclose(fid)
+
+    # bar.txtを作って書き込むテスト
+    puts "\nHey, create bar.txt and write down"
+    # wは書き込みモード
+    fid = ESP32_STDIO.fopen("/sdcard/bar.txt", "w")
+    # fputsで書き込む
+    ESP32_STDIO.fputs(fid, "Hello mruby/c!")
+    # fputcは最初の文字だけ書き込まれる
+    ESP32_STDIO.fputc(fid, "?")
+    ESP32_STDIO.fclose(fid)
+
+    # 名前の変更テスト
+    puts "\nYo! rename bar.txt to piyo.txt and read it!"
+    # bar.txtからpiyo.txtへ
+    ESP32_STDIO.rename("/sdcard/bar.txt", "/sdcard/piyo.txt")
+
+    # piyo.txtがちゃんとあるか確認してみる
+    fid = ESP32_STDIO.fopen("/sdcard/piyo.txt", "r")
+    # "Hello mruby/c!?"と出てくるはず
+    cont =ESP32_STDIO.fgets(fid,64)
+
+    # シークのテスト
+    puts "\n Let's fseek!"
+    # 先頭から5文字目(0から数えて4)に移動する．0は先頭から，1は現在位置から，2は最後から
+    ESP32_STDIO.fseek(fid, 4, 0)
+    # 現在の位置は？（4になるはず）
+    pos = ESP32_STDIO.fgetpos(fid)
+    puts "position is ", pos
+    puts "\n fgetc, Yah!"
+    # 5文字目のHelloのoが表示されるはず
+    puts ESP32_STDIO.fgetc(fid)
+    puts cont
+    ESP32_STDIO.fclose(fid)
+
+    # ファイル・フォルダ一覧を見てみよう
+    puts "\nGet ls /sdcard!"
+    ls = ESP32_DIRENT.children("/sdcard")
+    p ls
+
+    # ファイルの更新日時を調べてみよう
+    puts "\nWhen created? Check it now!"
+    t = ESP32_DIRENT.fileTime("/sdcard/piyo.txt")
+    puts "Year:", t.getYear()
+    puts "Month:", t.getMonth()
+    
+    # 後片付け
+    SDSPI.esp_vfs_fat_sdcard_unmount()
+
+  else
+    puts "vfat mount error"
+  end
+  SDSPI.spi_bus_free()
+else
+  puts "bus initialize error"
+end
+
+while true
+  puts "hello world from ESP32"
+  sleep 100
+end

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -38,5 +38,11 @@ menu "IoTeX ESP32 mrubyc Configuration"
         help
             use HTTP_CLIENT function?
 
+    config USE_ESP32_SPI_SD
+        bool "USR ESP32 SPI_SD"
+        default n
+        help
+            use use SPI SD function?
+
 endmenu
 

--- a/main/main.c
+++ b/main/main.c
@@ -29,6 +29,11 @@
 #ifdef CONFIG_USE_ESP32_HTTP_CLIENT
 #include "mrbc_esp32_http_client.h"
 #endif
+#ifdef CONFIG_USE_ESP32_SPI_SD
+#include "mrbc_esp32_sdspi.h"
+#include "mrbc_esp32_stdio.h"
+#include "mrbc_esp32_dirent.h"
+#endif
 
 // #include "models/[replace with your file].h"
 // #include "loops/[replace with your file].h"
@@ -152,6 +157,12 @@ void app_main(void) {
 #ifdef CONFIG_USE_ESP32_HTTP_CLIENT
   printf("start HTTPClient\n");
   mrbc_mruby_esp32_httpclient_gem_init(0);
+#endif
+#ifdef CONFIG_USE_ESP32_SPI_SD
+  printf("start SDSPI and ESP32 stdio\n");
+  mrbc_mruby_esp32_sdspi_gem_init(0);
+  mrbc_mruby_esp32_stdio_gem_init(0);
+  mrbc_mruby_esp32_dirent_gem_init(0);
 #endif
 
   mrbc_create_task( irq_handler, 0 );

--- a/main/mrbc_esp32_dirent.c
+++ b/main/mrbc_esp32_dirent.c
@@ -1,0 +1,218 @@
+/*! @file
+   @brief
+   mruby/c dirent class for ESP32
+*/
+
+#include "dirent.h"
+#include "sys/stat.h"
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <time.h>
+#include "esp_log.h"
+#include "mrbc_esp32_dirent.h"
+
+static struct RClass * mrbc_class_esp32_dirent;
+static struct RClass * mrbc_class_esp32_filetime;
+static mrbc_sym symid_systemtime_year;
+static mrbc_sym symid_systemtime_month;
+static mrbc_sym symid_systemtime_day;
+static mrbc_sym symid_systemtime_dayOfWeek;
+static mrbc_sym symid_systemtime_hour;
+static mrbc_sym symid_systemtime_minute;
+static mrbc_sym symid_systemtime_second;
+
+/*! Enumearte files contained selected directory.
+    @param directryname Selecting Directory Name
+    @return if succeeded, return String Array contains file names.
+            otherwise nil.
+ */
+static void
+mrbc_esp32_dir_files(mrb_vm * vm, mrb_value * v, int argc) {
+  DIR * dir = NULL;
+  struct dirent * dirInfo;
+  dir = opendir((char *)GET_STRING_ARG(1));
+  if(!dir) {
+    SET_NIL_RETURN();
+    return;
+  }
+  uint16_t fileCount = 0;
+  while(1) {
+    dirInfo = readdir(dir);
+    if(dirInfo == NULL) break;
+    if(dirInfo->d_type == DT_REG)
+      fileCount++;
+  }
+  mrbc_dec_ref_counter(v);
+  v[0] = mrbc_array_new(vm, (int)fileCount);
+  if(fileCount <= 0)
+    return;
+  rewinddir(dir);
+  for(int i = 0; i < fileCount;) {
+    dirInfo = readdir(dir); 
+    if(dirInfo == NULL) break; // ERROR!
+    if(dirInfo->d_type != DT_REG)
+      continue;
+    mrbc_value val = mrbc_string_new_cstr(vm, dirInfo->d_name);
+    mrbc_array_set(v, i, &val);
+    i++;
+  }
+}
+
+/*! Enumearte directories contained selected directory.
+    @param directryname Selecting Directory Name
+    @return if succeeded, return String Array contains directory names.
+            otherwise nil.
+*/
+static void
+mrbc_esp32_dir_dirs(mrb_vm * vm, mrb_value * v, int argc) {
+  DIR * dir = NULL;
+  struct dirent * dirInfo;
+  dir = opendir((char *)GET_STRING_ARG(1));
+  if(!dir) {
+    SET_NIL_RETURN();
+    return;
+  }
+  uint16_t dirCount = 0;
+  while(1) {
+    dirInfo = readdir(dir);
+    if(dirInfo == NULL) break;
+    if(dirInfo->d_type == DT_DIR)
+      dirCount++;
+  }
+  mrbc_dec_ref_counter(v);
+  v[0] = mrbc_array_new(vm, (int)dirCount);
+  if(dirCount <= 0)
+    return;
+  rewinddir(dir);
+  for(int i = 0; i < dirCount;) {
+    dirInfo = readdir(dir); 
+    if(dirInfo == NULL) break; // ERROR!
+    if(dirInfo->d_type != DT_DIR)
+      continue;
+    mrbc_value val = mrbc_string_new_cstr(vm, dirInfo->d_name);
+    mrbc_array_set(v, i, &val);
+    i++;
+  }
+}
+
+/*! Enumearte files and directories (= entry) contained selected directory.
+    @param directryname Selecting Directory Name
+    @return if succeeded, return String Array contains entry names.
+            otherwise nil.
+*/
+static void
+mrbc_esp32_dir_children(mrb_vm * vm, mrb_value * v, int argc) {
+  DIR * dir = NULL;
+  struct dirent * dirInfo;
+  dir = opendir((char *)GET_STRING_ARG(1));
+  if(!dir) {
+    SET_NIL_RETURN();
+    return;
+  }
+  uint16_t childCount = 0;
+  while(1) {
+    dirInfo = readdir(dir);
+    if(dirInfo == NULL) break;
+    childCount++;
+  }
+  mrbc_dec_ref_counter(v);
+  v[0] = mrbc_array_new(vm, (int)childCount);
+  if(childCount <= 0)
+    return;
+  rewinddir(dir);
+  for(int i = 0; i < childCount;) {
+    dirInfo = readdir(dir); 
+    if(dirInfo == NULL) break; // ERROR!
+    mrbc_value val = mrbc_string_new_cstr(vm, dirInfo->d_name);
+    mrbc_array_set(v, i, &val);
+    i++;
+  }
+}
+
+/*! Get file created time. 
+    @param name file or directory name
+    @return if succeeded, return ESP32_FILETIME.
+            otherwise nil.
+*/
+static void
+mrbc_esp32_file_time(mrb_vm* vm, mrb_value* v, int argc) {
+  struct stat fileInfo;
+  memset(&fileInfo, 0, sizeof(struct stat));
+  if(stat((char *)GET_STRING_ARG(1), &fileInfo)) {
+    SET_NIL_RETURN();
+  } else {
+    struct tm * ptm = gmtime(&fileInfo.st_ctime);
+    mrbc_value instance = mrbc_instance_new(vm, mrbc_class_esp32_filetime, 0);
+    mrbc_value year = mrbc_fixnum_value(ptm->tm_year + 1900);
+    mrbc_value month = mrbc_fixnum_value(ptm->tm_mon + 1);
+    mrbc_value day = mrbc_fixnum_value(ptm->tm_mday);
+    mrbc_value dayOfWeek = mrbc_fixnum_value(ptm->tm_wday);
+    mrbc_value hour = mrbc_fixnum_value(ptm->tm_hour);
+    mrbc_value minute = mrbc_fixnum_value(ptm->tm_min);
+    mrbc_value second = mrbc_fixnum_value(ptm->tm_sec);
+    mrbc_instance_setiv(&instance, symid_systemtime_year, &year);
+    mrbc_instance_setiv(&instance, symid_systemtime_month, &month);
+    mrbc_instance_setiv(&instance, symid_systemtime_day, &day);
+    mrbc_instance_setiv(&instance, symid_systemtime_dayOfWeek, &dayOfWeek);
+    mrbc_instance_setiv(&instance, symid_systemtime_hour, &hour);
+    mrbc_instance_setiv(&instance, symid_systemtime_minute, &minute);
+    mrbc_instance_setiv(&instance, symid_systemtime_second, &second);
+    mrbc_dec_ref_counter(v);
+    v[0] = instance;
+  }
+}
+
+static void
+mrbc_esp32_file_time_getYear(mrb_vm * vm, mrb_value * v, int argc) {
+  SET_RETURN(mrbc_instance_getiv(v, symid_systemtime_year));
+}
+static void
+mrbc_esp32_file_time_getMonth(mrb_vm * vm, mrb_value * v, int argc){
+  SET_RETURN(mrbc_instance_getiv(v, symid_systemtime_month));
+}
+static void
+mrbc_esp32_file_time_getDay(mrb_vm * vm, mrb_value * v, int argc) {
+  SET_RETURN(mrbc_instance_getiv(v, symid_systemtime_day));
+}
+static void
+mrbc_esp32_file_time_getDayOfWeek(mrb_vm * vm, mrb_value * v, int argc) {
+  SET_RETURN(mrbc_instance_getiv(v, symid_systemtime_dayOfWeek));
+}
+static void
+mrbc_esp32_file_time_getHour(mrb_vm * vm, mrb_value * v, int argc) {
+  SET_RETURN(mrbc_instance_getiv(v, symid_systemtime_hour));
+}
+static void
+mrbc_esp32_file_time_getMinute(mrb_vm * vm, mrb_value * v, int argc) {
+  SET_RETURN(mrbc_instance_getiv(v, symid_systemtime_minute));
+}
+static void
+mrbc_esp32_file_time_getSecond(mrb_vm * vm, mrb_value * v, int argc) {
+  SET_RETURN(mrbc_instance_getiv(v, symid_systemtime_second));
+}
+void mrbc_mruby_esp32_dirent_gem_init(struct VM* vm)
+{
+  mrbc_class_esp32_dirent = mrbc_define_class(vm, "ESP32_DIRENT", mrbc_class_object);
+  mrbc_define_method(vm, mrbc_class_esp32_dirent, "childrenFiles", mrbc_esp32_dir_files);
+  mrbc_define_method(vm, mrbc_class_esp32_dirent, "childrenDirs", mrbc_esp32_dir_dirs);
+  mrbc_define_method(vm, mrbc_class_esp32_dirent, "children", mrbc_esp32_dir_children);
+  mrbc_define_method(vm, mrbc_class_esp32_dirent, "fileTime", mrbc_esp32_file_time);
+
+  mrbc_class_esp32_filetime = mrbc_define_class(vm, "ESP32_FILETIME", mrbc_class_object);
+  mrbc_define_method(vm, mrbc_class_esp32_filetime, "getYear", mrbc_esp32_file_time_getYear);
+  mrbc_define_method(vm, mrbc_class_esp32_filetime, "getMonth", mrbc_esp32_file_time_getMonth);
+  mrbc_define_method(vm, mrbc_class_esp32_filetime, "getDay", mrbc_esp32_file_time_getDay);
+  mrbc_define_method(vm, mrbc_class_esp32_filetime, "getDayOfWeek", mrbc_esp32_file_time_getDayOfWeek);
+  mrbc_define_method(vm, mrbc_class_esp32_filetime, "getHour", mrbc_esp32_file_time_getHour);
+  mrbc_define_method(vm, mrbc_class_esp32_filetime, "getMinute", mrbc_esp32_file_time_getMinute);
+  mrbc_define_method(vm, mrbc_class_esp32_filetime, "getSecond", mrbc_esp32_file_time_getSecond);
+  
+  symid_systemtime_year = str_to_symid("year");
+  symid_systemtime_month = str_to_symid("month");
+  symid_systemtime_day = str_to_symid("day");
+  symid_systemtime_dayOfWeek = str_to_symid("dayOfWeek");
+  symid_systemtime_hour = str_to_symid("hour");
+  symid_systemtime_minute = str_to_symid("minute");
+  symid_systemtime_second = str_to_symid("second");
+}

--- a/main/mrbc_esp32_dirent.h
+++ b/main/mrbc_esp32_dirent.h
@@ -1,0 +1,8 @@
+#ifndef MRBC_ESP32_DIRENT_H
+#define MRBC_ESP32_DIRENT_H
+
+#include "mrubyc.h"
+
+void mrbc_mruby_esp32_dirent_gem_init(struct VM*);
+
+#endif // MRBC_ESP32_DIRENT_H

--- a/main/mrbc_esp32_sdspi.c
+++ b/main/mrbc_esp32_sdspi.c
@@ -1,0 +1,126 @@
+/*! @file
+  @brief
+  mruby/c SPI connected SD low-level class for ESP32
+*/
+
+#include "mrbc_esp32_sdspi.h"
+#include "esp_err.h"
+#include "esp_log.h"
+#include "esp_vfs_fat.h"
+#include "driver/sdspi_host.h"
+#include "driver/spi_common.h"
+#include "sdmmc_cmd.h"
+
+#include <stdlib.h>
+
+#include "driver/sdmmc_host.h"
+
+#define SPI_DMA_CHAN host.slot
+
+static struct RClass* mrbc_class_esp32_sdspi;
+
+static sdmmc_host_t host; // init after.
+static sdmmc_card_t * card;
+static char * mount_point;
+
+/*! Method spi_bus_initialize(mosi, miso, sclk) body : wrapper for spi_bus_initialize.
+
+    @param mosi MOSI Pin Number
+           miso MISO Pin Number
+           sclk SPI Clock Pin Number
+    @return if succeeded, return true, otherwise return false.
+ */
+static void
+mrbc_esp32_sdspi_spi_bus_initialize(mrb_vm* vm, mrb_value* v, int argc)
+{
+  spi_bus_config_t bus_cfg = {
+			      .mosi_io_num = GET_INT_ARG(1),
+			      .miso_io_num = GET_INT_ARG(2),
+			      .sclk_io_num = GET_INT_ARG(3),
+			      .quadwp_io_num = -1,
+			      .quadhd_io_num = -1,
+			      .max_transfer_sz = 4000
+  };
+  esp_err_t ret = spi_bus_initialize(host.slot, &bus_cfg, SPI_DMA_CHAN);
+  if(ret == ESP_OK)
+    SET_TRUE_RETURN();
+  else
+    SET_FALSE_RETURN();
+}
+
+/*! Method esp_vfs_fat_sdcard_mount(chipselect, mountpoint) body : wrapper for esp_vfs_fat_sdcard_mount.
+    @param chipselect ChipSelect Pin Number
+           mountpoint Mount Point Directory Name
+	   (optional) createiffailed  Create partition if mount failed.
+    @return if succeeded, return true, otherwise return false;
+*/
+static void
+mrbc_esp32_sdspi_esp_vfs_fat_sdspi_mount(mrb_vm* vm, mrb_value* v, int argc)
+{
+  if(mount_point != NULL) {
+    SET_FALSE_RETURN(); // can mount only one sd card.
+    return;
+  }
+  sdspi_device_config_t slot_config = SDSPI_DEVICE_CONFIG_DEFAULT();
+  slot_config.gpio_cs = GET_INT_ARG(1);
+  slot_config.host_id = host.slot;
+  esp_vfs_fat_sdmmc_mount_config_t mount_config = {
+						   .format_if_mount_failed = (argc >= 3 && GET_ARG(3).tt == MRBC_TT_TRUE),
+					  .max_files = 8,
+					  .allocation_unit_size = 16 * 1024
+  };
+  esp_err_t ret = esp_vfs_fat_sdspi_mount((char *)GET_STRING_ARG(2), &host, &slot_config, &mount_config, &card);
+  if(ret == ESP_OK)
+  {
+    mount_point = (char *)malloc((mrbc_string_size(&(v[2])) + 1) * sizeof(char));
+    memcpy(mount_point, GET_STRING_ARG(2), mrbc_string_size(&(v[2])) + 1);
+    SET_TRUE_RETURN();
+  }
+  else 
+    SET_FALSE_RETURN(); // if ESP_FAIL, filesystem is invalid, other is sd card should have pull-up resistors in place.
+}
+
+/*! Method esp_vfs_fat_sdcard_unmount() body : wrapper for esp_vfs_fat_sdcard_unmount.
+    @return if succeeded, return true, otherwise return false;
+*/
+static void
+mrbc_esp32_sdspi_esp_vfs_fat_sdcard_unmount(mrb_vm* vm, mrb_value *v, int argc)
+{
+  if(card == NULL && mount_point == NULL) // not initialized.
+  {
+    SET_FALSE_RETURN();
+    return;
+  }
+  esp_vfs_fat_sdcard_unmount(mount_point, card);
+  free(mount_point);
+  mount_point = NULL;
+  card = NULL;
+  SET_TRUE_RETURN();
+}
+
+/*! Method spi_bus_free() body : wrapper for spi_bus_free.
+*/
+static void
+mrbc_esp32_sdspi_spi_bus_free(mrb_vm* vm, mrb_value* v, int argc)
+{
+  spi_bus_free(host.slot);
+}
+
+/*! Register SDSPI Class.
+ */
+void
+mrbc_mruby_esp32_sdspi_gem_init(struct VM* vm)
+{
+  //host = SDSPI_HOST_DEFAULT();
+  sdmmc_host_t h_copy = SDSPI_HOST_DEFAULT();
+  host = h_copy;
+  card = NULL;
+  mount_point = NULL;
+
+  mrbc_class_esp32_sdspi = mrbc_define_class(vm, "SDSPI", mrbc_class_object);
+  mrbc_define_method(vm, mrbc_class_esp32_sdspi, "spi_bus_initialize", mrbc_esp32_sdspi_spi_bus_initialize);
+  mrbc_define_method(vm, mrbc_class_esp32_sdspi, "esp_vfs_fat_sdspi_mount", mrbc_esp32_sdspi_esp_vfs_fat_sdspi_mount);
+  mrbc_define_method(vm, mrbc_class_esp32_sdspi, "esp_vfs_fat_sdcard_unmount", mrbc_esp32_sdspi_esp_vfs_fat_sdcard_unmount);
+  mrbc_define_method(vm, mrbc_class_esp32_sdspi, "spi_bus_free", mrbc_esp32_sdspi_spi_bus_free);
+
+}

--- a/main/mrbc_esp32_sdspi.h
+++ b/main/mrbc_esp32_sdspi.h
@@ -1,0 +1,8 @@
+#ifndef MRBC_ESP32_SDSPI_H
+#define MRBC_ESP32_SDSPI_H
+
+#include "mrubyc.h"
+
+void mrbc_mruby_esp32_sdspi_gem_init(struct VM*);
+
+#endif // MRBC_ESP32_SDSPI_H

--- a/main/mrbc_esp32_stdio.c
+++ b/main/mrbc_esp32_stdio.c
@@ -1,0 +1,304 @@
+/*! @file
+   @brief
+   POSIX compatible? mruby/c stdio class for ESP32
+*/
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include "esp_log.h"
+#include "mrbc_esp32_stdio.h"
+
+static struct RClass * mrbc_class_esp32_stdio;
+
+static FILE* fidfptable[8] = {0};
+static char used = 0;
+
+/*! fopen compatible method. Open the file and return file id.
+    (In this library, Ruby cannot have FILE pointer, beacuse FIXNUM is 31 bit(maybe...))
+    @param filename File Name to open
+           openmode "r" read or "w" write. If binary, append "b". If appending mode, append "+"
+    @return Return file id(= FIXNUM)
+            If you opened more than 8 files or fopen failed, error file id, -1.
+*/
+static void
+mrbc_esp32_fopen(mrb_vm* vm, mrb_value* v, int argc) {
+  int ret_fid = 0;
+  for(; ret_fid < 8; ++ret_fid)
+    if((used & (1 << ret_fid)) == 0)
+      break;
+  if(ret_fid == 8) {
+    SET_INT_RETURN(-1); // opend file are too many.
+    return;
+  }
+  fidfptable[ret_fid] = fopen((char *)GET_STRING_ARG(1), (char *)GET_STRING_ARG(2));
+  if(fidfptable[ret_fid] == NULL)
+    SET_INT_RETURN(-1); // open failed.
+  else {
+    used |= (1 << ret_fid);
+    SET_INT_RETURN(ret_fid);
+  }
+}
+
+/*! fclose compatible method. Close the file given file id.
+    @param fid file id to close
+    @return If succeeded, return true, otherwise false.
+*/
+static void
+mrbc_esp32_fclose(mrb_vm* vm, mrb_value* v, int argc) {
+  int fid = GET_INT_ARG(1);
+  if((used & (1 << fid)) == 0) {
+    SET_FALSE_RETURN(); // file is not available.
+    return;
+  }
+  if(fclose(fidfptable[fid])) // ERROR
+    SET_FALSE_RETURN();
+  else
+    SET_TRUE_RETURN();
+  fidfptable[fid] = NULL;
+  used = used & ~(1 << fid);
+}
+
+/*! fputs compatible method. Write down the string onto given file.
+    @param  fid file id to puts
+            content content to write
+    @return If succeeded, return true, otherwise false.
+*/
+static void
+mrbc_esp32_fputs(mrb_vm * vm, mrb_value * v, int argc) {
+  int fid = GET_INT_ARG(1);
+  if((used & (1 << fid)) == 0) {
+    SET_FALSE_RETURN(); // file is not available.
+    return;
+  }
+  if(fputs((char *)GET_STRING_ARG(2), fidfptable[fid]) == EOF)
+    SET_FALSE_RETURN();
+  else
+    SET_TRUE_RETURN();
+}
+
+
+/*! fwrite compatible method. Write down the binary array onto given file.
+    @param  fid file id to puts
+            content content to write
+            size length of element
+            nmemb count of element
+    @return If succeeded, return true, otherwise false.
+*/
+static void
+mrbc_esp32_fwrite(mrb_vm * vm, mrb_value * v, int argc) {
+  int fid = GET_INT_ARG(1);
+  if((used & (1 << fid)) == 0) {
+    SET_FALSE_RETURN(); // file is not available.
+    return;
+  }
+  if(fwrite((char *)GET_STRING_ARG(2), GET_INT_ARG(3), GET_INT_ARG(4), fidfptable[fid]) == EOF)
+    SET_FALSE_RETURN();
+  else
+    SET_TRUE_RETURN();
+}
+
+/*! fputc compatible method. Write down one charactor onto given file.
+    @param fid file id to putc
+           ch character to write
+    @return If succeeded, return true, otherwise false.
+*/
+static void
+mrbc_esp32_fputc(mrb_vm * vm, mrb_value * v, int argc) {
+  int fid = GET_INT_ARG(1);
+  if((used & (1 << fid)) == 0) {
+    SET_FALSE_RETURN(); // file is not available.
+    return;
+  }
+  if(fputc((char)(GET_STRING_ARG(2))[0], fidfptable[fid]) == EOF)
+    SET_FALSE_RETURN();
+  else
+    SET_TRUE_RETURN();
+}
+
+/*! fgets compatible method. Read from given file.
+    @param fid file id to gets
+           length read size
+    @return If succeeded, return true, otherwise false.
+*/
+static void
+mrbc_esp32_fgets(mrb_vm * vm, mrb_value * v, int argc) {
+  int fid = GET_INT_ARG(1);
+  if((used & (1 << fid)) == 0) {
+    SET_NIL_RETURN(); // file is not available.
+    return;
+  }
+  char * buf = (char *)malloc(sizeof(char) * GET_INT_ARG(2));
+  if(fgets(buf, GET_INT_ARG(2), fidfptable[fid]) == NULL) {
+    SET_NIL_RETURN();
+    free(buf);
+    return;
+  }
+  mrbc_value ret = mrbc_string_new_cstr(vm, buf);
+  free(buf);
+  mrbc_dec_ref_counter(v);
+  v[0] = ret;
+}
+
+/*! fread compatible method. Read from given file.
+    @param fid file id to gets
+           size length of element
+           nmemb count of element
+    @return If succeeded, return true, otherwise false.
+*/
+static void
+mrbc_esp32_fread(mrb_vm * vm, mrb_value * v, int argc) {
+  int fid = GET_INT_ARG(1);
+  if((used & (1 << fid)) == 0) {
+    SET_NIL_RETURN(); // file is not available.
+    return;
+  }
+  char * buf = (char *)malloc(GET_INT_ARG(2) * GET_INT_ARG(3));
+  int read_len = fread(buf, GET_INT_ARG(2), GET_INT_ARG(3), fidfptable[fid]);
+  if( read_len == 0) {
+    SET_NIL_RETURN();
+    free(buf);
+    return;
+  }
+  mrbc_value ret = mrbc_string_new(vm, buf, GET_INT_ARG(2) * read_len);
+  free(buf);
+  mrbc_dec_ref_counter(v);
+  v[0] = ret;
+}
+
+/*! fgetc compatible method. Read one charactor from given file.
+    @param fid file id to gets
+    @return If succeeded, return true, otherwise nil.
+*/
+static void
+mrbc_esp32_fgetc(mrb_vm * vm, mrb_value *v, int argc) {
+  int fid = GET_INT_ARG(1);
+  if((used & (1 << fid)) == 0) {
+    SET_NIL_RETURN(); // file is not available.
+    return;
+  }
+  mrbc_value ret = mrbc_string_new(vm, NULL, 1);
+  ret.string->data[0] = (uint8_t)fgetc(fidfptable[fid]);
+  mrbc_dec_ref_counter(v);
+  v[0] = ret;
+}
+
+/*! remove compatible method. Remove file whose name is given name.
+    @param filename file to be removed
+    @return if succeeded, return true, otherwise false.
+*/
+static void
+mrbc_esp32_remove(mrb_vm * vm, mrb_value * v, int argc) {
+  if(remove((char *)GET_STRING_ARG(1))) {
+    // error.
+    SET_FALSE_RETURN();
+  } else {
+    SET_TRUE_RETURN();
+  }
+}
+
+/*! rename compatible method. Rename files.
+    @param src file to be renamed
+           dst destination file name
+    @return if succeeded, return true, otherwise false.
+*/
+static void
+mrbc_esp32_rename(mrb_vm* vm, mrb_value* v, int argc) {
+
+  if(rename((char *)GET_STRING_ARG(1), (char *)GET_STRING_ARG(2)))
+    SET_FALSE_RETURN(); // rename failed.
+  else
+    SET_TRUE_RETURN();
+}
+
+/*! fflush compatible method. Flush pending data immediately.
+    @param fid file id to be flushed
+    @return If succeeded, return true, otherwise false.
+*/
+static void
+mrbc_esp32_fflush(mrb_vm * vm, mrb_value * v, int argc) {
+  int fid = GET_INT_ARG(1);
+  if((used & (1 << fid)) == 0) {
+    SET_FALSE_RETURN(); // file is not available.
+    return;
+  }
+  if(fflush(fidfptable[fid])) {
+    // error.
+    SET_FALSE_RETURN();
+  } else {
+    SET_TRUE_RETURN();
+  }
+}
+
+/*! fgetpos compatible method. Get position of cursor.
+    @param fid file id to get position
+    @return If succeeded, return position of cursor, otherwise nil.
+*/
+static void
+mrbc_esp32_fgetpos(mrb_vm * vm, mrb_value * v, int argc) {
+  int fid = GET_INT_ARG(1);
+  if((used & (1 << fid)) == 0) {
+    SET_NIL_RETURN(); // file is not available.
+    return;
+  }
+  fpos_t ret;
+  if(fgetpos(fidfptable[fid], &ret))
+    SET_NIL_RETURN();
+  else
+    SET_INT_RETURN(ret);
+}
+
+/*! fsetpos compatible method. Set position of cursor.
+    @param fid file id to set position
+    @return If succeeded, return true, otherwise false.
+*/
+static void
+mrbc_esp32_fsetpos(mrb_vm * vm, mrb_value * v, int argc) {
+  int fid = GET_INT_ARG(1);
+  if((used & (1 << fid)) == 0) {
+    SET_FALSE_RETURN(); // file is not available.
+    return;
+  }
+  fpos_t val = (fpos_t)GET_INT_ARG(2);
+  if(fsetpos(fidfptable[fid], &val))
+    SET_FALSE_RETURN();
+  else
+    SET_TRUE_RETURN();
+}
+
+/*! fseek compatible method. Seek position of cursor.
+    @param fid file id to seek cursor
+           origin SEEK_SET(0) or SEEK_CUR(1) or SEEK_END(2)
+                  from head   or from cursor or from end of file
+    @return If succeeded, return true, otherwise false.
+*/
+static void
+mrbc_esp32_fseek(mrb_vm * vm, mrb_value * v, int argc) {
+  int fid = GET_INT_ARG(1);
+  if((used & (1 << fid)) == 0) {
+    SET_FALSE_RETURN(); // file is not available.
+    return;
+  }
+  if(fseek(fidfptable[fid], GET_INT_ARG(2), GET_INT_ARG(3)))
+    SET_FALSE_RETURN();
+  else
+    SET_TRUE_RETURN();
+}
+
+void mrbc_mruby_esp32_stdio_gem_init(struct VM* vm) {
+  mrbc_class_esp32_stdio = mrbc_define_class(vm, "ESP32_STDIO", mrbc_class_object);
+  mrbc_define_method(vm, mrbc_class_esp32_stdio, "fopen", mrbc_esp32_fopen);
+  mrbc_define_method(vm, mrbc_class_esp32_stdio, "fputs", mrbc_esp32_fputs);
+  mrbc_define_method(vm, mrbc_class_esp32_stdio, "fputc", mrbc_esp32_fputc);
+  mrbc_define_method(vm, mrbc_class_esp32_stdio, "fgets", mrbc_esp32_fgets);
+  mrbc_define_method(vm, mrbc_class_esp32_stdio, "fgetc", mrbc_esp32_fgetc);
+  mrbc_define_method(vm, mrbc_class_esp32_stdio, "fflush", mrbc_esp32_fflush);
+  mrbc_define_method(vm, mrbc_class_esp32_stdio, "fgetpos", mrbc_esp32_fgetpos);
+  mrbc_define_method(vm, mrbc_class_esp32_stdio, "fsetpos", mrbc_esp32_fsetpos);
+  mrbc_define_method(vm, mrbc_class_esp32_stdio, "fseek", mrbc_esp32_fseek);
+  mrbc_define_method(vm, mrbc_class_esp32_stdio, "remove", mrbc_esp32_remove);
+  mrbc_define_method(vm, mrbc_class_esp32_stdio, "fclose", mrbc_esp32_fclose);
+  mrbc_define_method(vm, mrbc_class_esp32_stdio, "rename", mrbc_esp32_rename);
+  mrbc_define_method(vm, mrbc_class_esp32_stdio, "fread", mrbc_esp32_fread);
+  mrbc_define_method(vm, mrbc_class_esp32_stdio, "fwrite", mrbc_esp32_fwrite);
+}

--- a/main/mrbc_esp32_stdio.h
+++ b/main/mrbc_esp32_stdio.h
@@ -1,0 +1,9 @@
+#ifndef MRBC_ESP32_STDIO_H
+#define MRBC_ESP32_STDIO_H
+
+#include "mrubyc.h"
+
+void mrbc_mruby_esp32_stdio_gem_init(struct VM*);
+
+#endif // MRBC_ESP32_STDIO_H
+


### PR DESCRIPTION
# Description
This commit adds ESP32's SPI SD Host Controller support for mruby/c.  
You can use `stdio.h` and `driver/sdspi_host.h` APIs from mruby/c with this commit.  

## Warning
This program doesn't check arguments.  
So if you use wrongly(e.g. you passed wrong typed values or not enough count of arguments), it segfaults.

## Additional Information
(C) Matsue College of Technology.  
このプログラムは松江高専の授業中に作成されました．  

# Added APIs
## SDSPI class
This class have methods about SPI initialization and FileSystem mounting.  
#### Limitation

This class only have one SD card and first partition.  
You want to extend to be able to use multiple SD card, you should create instancing-able class about SD card.  
That class must hold `sdmmc_host_t` and `sdmmc_card_t`.  
mruby/c seems to have special method to create instance with additional space to remember C structures, but it is not documented and cannot guarantee the class have additional space DEFINITELY.  

If you want to see second and later partitions, you may create vfs program yourself because I can't find any API to look other partitions.

### SDSPI#spi_bus_initialize(mosi : Integer, miso : Integer, sclk : Integer) -> bool
Pass SPI pin numbers, MOSI(Master out slave in), MISO(Master in slave out), SCLK(SPI Clock).  
This method initializes SPI Bus.  
If success, return `true`, otherwise `false`.

### SDSPI#esp_vfs_fat_sdcard_mount(cs : Integer, mount_point : String) -> bool
Pass CS(Chip Select, also called Slave Select).  
2nd argument is a path where to mount on. e.g. `"/sdcard"`.  
This method initializes vfs module and mount file system.  
If success, return `true`, otherwise `false`.

### SDSPI#esp_vfs_fat_sdcard_unmount() -> bool
This method unmounts file system.  
If success, return `true`, otherwise `false`.

### SDSPI#spi_bus_free() : bool
This method frees the SPI Bus.  
This returns nothing.

## ESP32_STDIO class
This class provides `stdio.h` functions.  
#### Limitation
You can open up to 8 files.

### ESP32_STDIO#fopen(filename : String , openmode : String) -> Integer
See https://pubs.opengroup.org/onlinepubs/9699919799/functions/fopen.html  
This returns `file id` instead of `FILE` pointer. If fails, return `-1`.  

### ESP32_STDIO#fclose(fid : Integer) -> bool
See https://pubs.opengroup.org/onlinepubs/9699919799/functions/fclose.html  
This need `file id` instead of `FILE` pointer.  
If success, return `true`, otherwise `false`.

### ESP32_STDIO#fputs(fid : Integer, content : String) -> bool
See https://pubs.opengroup.org/onlinepubs/9699919799/functions/fputs.html  
This need `file id` instead of `FILE` pointer and `String` instead of `char` pointer.  
If success, return `true`, otherwise `false`.

### ESP32_STDIO#fputc(fid : Integer, content : String) -> bool
See https://pubs.opengroup.org/onlinepubs/9699919799/functions/fputc.html  
This need `file id` instead of `FILE` pointer and `String` instead of `char`.  
If success, return `true`, otherwise `false`.

### ESP32_STDIO#fwrite(fid : Integer, content : String, size : Integer, nitems : Integer) -> bool
See https://pubs.opengroup.org/onlinepubs/9699919799/functions/fwrite.html  
This need `file id` instead of `FILE` pointer and `String` instead of `char`.  
If success, return `true`, otherwise `false`.

### ESP32_STDIO#fputc(fid : Integer, content : String, size : Integer, nitems : Integer) -> bool
See https://pubs.opengroup.org/onlinepubs/9699919799/functions/fputc.html  
This need `file id` instead of `FILE` pointer and `String` instead of `char`.  
If success, return `true`, otherwise `false`.

### ESP32_STDIO#fgets(fid : Integer, length : Integer) -> String
See https://pubs.opengroup.org/onlinepubs/9699919799/functions/fgets.html  
This need `file id` instead of `FILE` pointer.  
If success, return content typed `String`, otherwise `nil`.

### ESP32_STDIO#fread(fid : Integer, size : Integer, nitems : Integer) -> String
See https://pubs.opengroup.org/onlinepubs/9699919799/functions/fread.html  
This need `file id` instead of `FILE` pointer.  
If success, return content typed `String`, otherwise `nil`.

### ESP32_STDIO#fgetc(fid : Integer, length : Integer) -> String
See https://pubs.opengroup.org/onlinepubs/9699919799/functions/fgetc.html  
This need `file id` instead of `FILE` pointer.  
If success, return content typed `String`, otherwise `nil`.

### ESP32_STDIO#fflush(fid : Integer) -> bool
See https://pubs.opengroup.org/onlinepubs/9699919799/functions/fflush.html  
This need `file id` instead of `FILE` pointer.  
If success, return `true`, otherwise `false`.

### ESP32_STDIO#fgetpos(fid : Integer) -> Integer
See https://pubs.opengroup.org/onlinepubs/9699919799/functions/fgetpos.html  
This need `file id` instead of `FILE` pointer.  
If success, return `true`, otherwise `false`.

### ESP32_STDIO#fsetpos(fid : Integer) -> Integer
See https://pubs.opengroup.org/onlinepubs/9699919799/functions/fsetpos.html  
This need `file id` instead of `FILE` pointer.  
If success, return `true`, otherwise `false`.

### ESP32_STDIO#fseek(fid : Integer, offset : Integer, whence : Integer) -> Integer
See https://pubs.opengroup.org/onlinepubs/9699919799/functions/fseek.html  
This need `file id` instead of `FILE` pointer.  
`SEEK_SET` is `0`, `SEEK_CUR` is `1`, `SEEK_END` is `2`.  
If success, return `true`, otherwise `false`.

### ESP32_STDIO#remove(filename : String) -> bool
See https://pubs.opengroup.org/onlinepubs/9699919799/functions/remove.html  
If success, return `true`, otherwise `false`.

### ESP32_STDIO#rename(src : String, dst : String) -> bool
See https://pubs.opengroup.org/onlinepubs/9699919799/functions/rename.html  
If success, return `true`, otherwise `false`.

## ESP32_DIRENT class
This class provides directory information and file time stamp API.  
### ESP32_DIRENT#childrenFiles(directory : Name) -> String[]
Enumerated files contained selected directory(argument `directory`).  
If succeeded, return array of String, name of files contained, otherwise `nil`.

### ESP32_DIRENT#childrenDirs(directory : Name) -> String[]
Enumerated directories contained selected directory(argument `directory`).  
If succeeded, return array of String, name of directories contained, otherwise `nil`.

### ESP32_DIRENT#children(directory : Name) -> String[]
Enumerated both files and directories contained selected directory(argument `directory`).  
If succeeded, return array of String, name of entries contained, otherwise `nil`.


### ESP32_DIRENT#fileTime(entryName : Name) -> ESP32_FILETIME
Get created date of given file.  
If succeeded, return `ESP32_FILETIME`, otherwise `nil`.  
`ESP32_FILETIME` have these members, all return values are `Integer`.  
`getYear()`, `getMonth()`, `getDay()`, `getDayOfWeek()`, `getHour()`, `getMinute()`, `getSecond()`.